### PR TITLE
remove the extra parens in this call

### DIFF
--- a/drone/tello/step4/main.go
+++ b/drone/tello/step4/main.go
@@ -25,7 +25,7 @@ func main() {
 			fmt.Println("Flip")
 		})
 
-		drone.TakeOff(())
+		drone.TakeOff()
 
 		gobot.Every(1*time.Second, func() {
 			printFlightData(currentFlightData)


### PR DESCRIPTION
This was causing a syntax error.

```
[step4] go run main.go                                                                           10:40:32  ☁  master ☀
# command-line-arguments
./main.go:28:18: syntax error: unexpected ), expecting expression
./main.go:30:37: syntax error: unexpected { at end of statement
./main.go:32:4: syntax error: unexpected ) at end of statement
./main.go:43:2: syntax error: non-declaration statement outside function body
```