### PR TITLE
Correct pin number 23 ➡️11 for the arduino step 2

### DIFF
--- a/sensor/arduino/README.md
+++ b/sensor/arduino/README.md
@@ -98,7 +98,7 @@ You should see the blue LED blink.
 
 - Connect a 10K Ohm resistor from pin 9 on the breadboard to pin 11 on the breadboard.
 
-- Connect a black jumper cable from the ground rail (-) on the breadboard to pin 23 on the breadboard.
+- Connect a black jumper cable from the ground rail (-) on the breadboard to pin 11 on the breadboard.
 
 - Connect pin 8 on the Arduino to pin 9 on the breadboard on the opposite side. Choose any color of cable besides red or black.
 


### PR DESCRIPTION
Pin number 23 is noted to be connected to the ground rail, but nothing else in that step uses pin 23, and the image shows the cable being connected to pin 11.

Co-authored-by: sagarkrkv <sagarkrkv@gmail.com>